### PR TITLE
Implement up-front type validation

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -82,7 +82,7 @@ module Sprinkles::Opts
         RB
       end
       if !valid_type?(type)
-        raise "#{type} is not a valid parameter type"
+        raise "`#{type}` is not a valid parameter type"
       end
 
       # we don't want to let the user pass in nil explicitly, so the

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -145,5 +145,15 @@ module Sprinkles
       msg = T.cast(msg, RuntimeError)
       assert(msg.message.include?('The options `-h` and `--help` are reserved'))
     end
+
+    def test_disallow_bad_types
+      msg = assert_raises(RuntimeError) do
+        Class.new(Sprinkles::Opts::GetOpt) do
+          T.unsafe(self).const(:foo, Proc, long: 'foo')
+        end
+      end
+      msg = T.cast(msg, RuntimeError)
+      assert_equal('`Proc` is not a valid parameter type', msg.message)
+    end
   end
 end


### PR DESCRIPTION
Add a method which can up-front validate whether a type is a sensible field type, rather than relying on lazy validation.

Closes #2.