### PR TITLE
Allow `T::Enum` values as fields

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -171,8 +171,8 @@ module Sprinkles::Opts
             args << "-#{o.short}" if o.short
             args << "--[no-]#{o.long}" if o.long
           else
-            args << "-#{o.short}#{o.get_placeholder}"
-            args << "--#{o.long}=#{o.get_placeholder}"
+            args << "-#{o.short}#{o.get_placeholder}" if o.short
+            args << "--#{o.long}=#{o.get_placeholder}" if o.long
           end
           args << o.description if o.description
           opts.on(*args) do |v|

--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -35,6 +35,12 @@ module Sprinkles::Opts
 
       sig { returns(String) }
       def get_placeholder
+        if type.is_a?(Class) && type < T::Enum
+          # if the type is an enum, we can enumerate the possible
+          # values in a rich way
+          possible_values = type.values.map(&:serialize).join("|")
+          return "[#{possible_values}]"
+        end
         placeholder || 'VALUE'
       end
     end

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -152,6 +152,7 @@ module Sprinkles
       msg = assert_raises(KeyError) do
         opts = OptsWithEnum.parse(%w[--value=seventeen])
       end
+      msg = T.cast(msg, KeyError)
       assert(msg.message.include?('key not found: "seventeen"'))
     end
 

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -130,6 +130,18 @@ module Sprinkles
       const :value, MyEnum, long: "value"
     end
 
+    def test_usage_string_for_enums
+      out_buf = StringIO.new
+      begin
+        $stdout = out_buf
+        OptsWithEnum.parse(['--help'])
+        $stdout = STDOUT
+      rescue SystemExit
+        help_text = out_buf.string
+        assert(help_text.include?('--value=[one|two]'))
+      end
+    end
+
     def test_enum_values
       opts = OptsWithEnum.parse(%w[--value=one])
       assert_equal(MyEnum::One, opts.value)

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -116,6 +116,33 @@ module Sprinkles
       assert_equal(100, opts.def_integer)
     end
 
+    class MyEnum < T::Enum
+      enums do
+        One = new('one')
+        Two = new('two')
+      end
+    end
+
+    class OptsWithEnum < Sprinkles::Opts::GetOpt
+      sig { override.returns(String) }
+      def self.program_name; "opts-with-enum"; end
+
+      const :value, MyEnum, long: "value"
+    end
+
+    def test_enum_values
+      opts = OptsWithEnum.parse(%w[--value=one])
+      assert_equal(MyEnum::One, opts.value)
+
+      opts = OptsWithEnum.parse(%w[--value=two])
+      assert_equal(MyEnum::Two, opts.value)
+
+      msg = assert_raises(KeyError) do
+        opts = OptsWithEnum.parse(%w[--value=seventeen])
+      end
+      assert(msg.message.include?('key not found: "seventeen"'))
+    end
+
     def test_disallow_leading_short_hyphens
       msg = assert_raises(RuntimeError) do
         Class.new(Sprinkles::Opts::GetOpt) do


### PR DESCRIPTION
This will use the `deserialize` method on the enum to deserialize the provided string, raising an exception if the value is not a valid deserialization. This also lists all possible values for the enum in the `--help` text.

That is to say, this code:

```ruby
    class MyEnum < T::Enum
      enums do
        One = new('one')
        Two = new('two')
      end
    end

    class OptsWithEnum < Sprinkles::Opts::GetOpt
      sig { override.returns(String) }
      def self.program_name; "opts-with-enum"; end

      const :value, MyEnum, long: "value"
    end
```

produces this help:

```
Usage: opts-with-enum [opts]
    -h, --help                       Prints this help
        --value=[one|two]
```