### PR TITLE
Implement parsing for positional arguments

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -169,23 +169,8 @@ module Sprinkles::Opts
       end
     end
 
-    sig { params(argv: T::Array[String]).returns(T.attached_class) }
-    def self.parse(argv)
-      values = {}
-      parser = OptionParser.new do |opts|
-        opts.banner = "Usage: #{program_name} [opts]"
-        opts.on('-h', '--help', 'Prints this help') do
-          puts opts
-          exit
-        end
-
-        fields.each do |field|
-          opts.on(*field.optparse_args) do |v|
-            values[field.name] = v
-          end
-        end
-      end.parse(argv)
-
+    sig { params(values: T::Array[String, String]).returns(T.attached_class) }
+    def self.build_config(values)
       o = new
       fields.each do |field|
         if field.type == T::Boolean
@@ -203,6 +188,26 @@ module Sprinkles::Opts
         end
       end
       o
+    end
+
+    sig { params(argv: T::Array[String]).returns(T.attached_class) }
+    def self.parse(argv)
+      values = {}
+      parser = OptionParser.new do |opts|
+        opts.banner = "Usage: #{program_name} [opts]"
+        opts.on('-h', '--help', 'Prints this help') do
+          puts opts
+          exit
+        end
+
+        fields.each do |field|
+          opts.on(*field.optparse_args) do |v|
+            values[field.name] = v
+          end
+        end
+      end.parse(argv)
+
+      build_config(values)
     end
 
     sig { returns(T.attached_class) }

--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -169,7 +169,7 @@ module Sprinkles::Opts
       end
     end
 
-    sig { params(values: T::Array[String, String]).returns(T.attached_class) }
+    sig { params(values: T::Hash[Symbol, String]).returns(T.attached_class) }
     def self.build_config(values)
       o = new
       fields.each do |field|
@@ -192,7 +192,7 @@ module Sprinkles::Opts
 
     sig { params(argv: T::Array[String]).returns(T.attached_class) }
     def self.parse(argv)
-      values = {}
+      values = T::Hash[Symbol, String].new
       parser = OptionParser.new do |opts|
         opts.banner = "Usage: #{program_name} [opts]"
         opts.on('-h', '--help', 'Prints this help') do

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -6,6 +6,21 @@ require 'sprinkles/opts'
 
 module Sprinkles
   class GetOptTest < Minitest::Test
+    extend T::Sig
+
+    sig {params(blk: T.proc.void).returns(String)}
+    def capture_usage(&blk)
+      out_buf = StringIO.new
+      begin
+        $stdout = out_buf
+        yield
+      rescue SystemExit
+        $stdout = STDOUT
+      end
+      help_text = out_buf.string
+      return help_text
+    end
+
     class SimpleOpt < Sprinkles::Opts::GetOpt
       sig { override.returns(String) }
       def self.program_name
@@ -43,18 +58,44 @@ module Sprinkles
     end
 
     def test_getopt_usage
-      out_buf = StringIO.new
-      begin
-        $stdout = out_buf
-        SimpleOpt.parse(['--help'])
-        $stdout = STDOUT
-      rescue SystemExit
-        help_text = out_buf.string
-        assert(help_text.include?('Usage: simple-opt [opts]'))
-        assert(help_text.include?('-i, --input=QUUX'))
-        assert(help_text.include?('-v, --[no-]verbose'))
-      end
+      help_text = capture_usage { SimpleOpt.parse(['--help']) }
+
+      assert(help_text.include?('Usage: simple-opt [opts]'))
+      assert(help_text.include?('-i, --input=QUUX'))
+      assert(help_text.include?('-v, --[no-]verbose'))
     end
+
+    class Positional < Sprinkles::Opts::GetOpt
+      sig { override.returns(String) }
+      def self.program_name
+        'positional'
+      end
+
+      const :first, String
+      const :second, Integer
+      const :third, T.nilable(Symbol)
+    end
+
+    def test_positional_params
+      opts = Positional.parse(%w[one 2 three])
+      assert_equal('one', opts.first)
+      assert_equal(2, opts.second)
+      assert_equal(:three, opts.third)
+
+      opts = Positional.parse(%w[one 2])
+      assert_equal('one', opts.first)
+      assert_equal(2, opts.second)
+      assert_nil(opts.third)
+    end
+
+    def test_positional_errors
+      msg = capture_usage { Positional.parse(%w[one]) }
+      assert(msg.include?('Not enough arguments'))
+
+      msg = capture_usage { Positional.parse(%w[one 2 three four]) }
+      assert(msg.include?('Too many arguments'))
+    end
+
 
     class RichTypes < Sprinkles::Opts::GetOpt
       sig { override.returns(String) }
@@ -131,15 +172,8 @@ module Sprinkles
     end
 
     def test_usage_string_for_enums
-      out_buf = StringIO.new
-      begin
-        $stdout = out_buf
-        OptsWithEnum.parse(['--help'])
-        $stdout = STDOUT
-      rescue SystemExit
-        help_text = out_buf.string
-        assert(help_text.include?('--value=[one|two]'))
-      end
+      help_text = capture_usage { OptsWithEnum.parse(['--help']) }
+      assert(help_text.include?('--value=[one|two]'))
     end
 
     def test_enum_values

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -91,11 +91,23 @@ module Sprinkles
     def test_positional_errors
       msg = capture_usage { Positional.parse(%w[one]) }
       assert(msg.include?('Not enough arguments'))
+      assert(msg.include?('FIRST SECOND [THIRD]'))
 
       msg = capture_usage { Positional.parse(%w[one 2 three four]) }
       assert(msg.include?('Too many arguments'))
     end
 
+    def test_all_mandatory_first
+      msg = assert_raises(RuntimeError) do
+        Class.new(Sprinkles::Opts::GetOpt) do
+          T.unsafe(self).const(:foo, T.nilable(String))
+          T.unsafe(self).const(:bar, String)
+        end
+      end
+      msg = T.cast(msg, RuntimeError)
+      assert(msg.message.include?('`bar` is a mandatory positional field'))
+      assert(msg.message.include?('after the optional field(s) `foo`'))
+    end
 
     class RichTypes < Sprinkles::Opts::GetOpt
       sig { override.returns(String) }


### PR DESCRIPTION
Fixes #5: this understands any field without a `short:` or `long:` argument as positional. Currently it imposes a restriction that all mandatory parameters must come first and all optional parameters afterwards, which allows us to easily match parameters in-order; this might be relaxed later, but with caution.

This also refactors a number of the internal interfaces, including how validation works and object construction currently works.