### PR TITLE
Clean up the `--help` text

### DIFF
--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -28,7 +28,7 @@ module Sprinkles
       end
 
       const :input, String, short: 'i', long: 'input', placeholder: 'QUUX'
-      const :verbose, T::Boolean, short: 'v', long: 'verbose'
+      const :verbose, T::Boolean, short: 'v', long: 'verbose', factory: -> {false}
     end
 
     def test_getopt_short
@@ -60,7 +60,7 @@ module Sprinkles
     def test_getopt_usage
       help_text = capture_usage { SimpleOpt.parse(['--help']) }
 
-      assert(help_text.include?('Usage: simple-opt [opts]'))
+      assert(help_text.include?('Usage: simple-opt --input=QUUX [OPTS...]'))
       assert(help_text.include?('-i, --input=QUUX'))
       assert(help_text.include?('-v, --[no-]verbose'))
     end


### PR DESCRIPTION
This does a few things:
1. the usage string now lists _all_ obligatory arguments as well as optional positional ones, trying to use long option names but falling back to short ones
2. the usage string does not list the final `[OPTS...]` unless there _are_ non-mandatory options
3. tweaks the wording of the help description