### PR TITLE
Respect factory fields for booleans

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -206,7 +206,9 @@ module Sprinkles::Opts
       serialized = {}
       fields.each do |field|
         if field.type == T::Boolean
-          v = !!values.fetch(field.name, false)
+          default = false
+          default = field.factory&.call if !field.factory.nil?
+          v = !!values.fetch(field.name, default)
         elsif values.include?(field.name)
           v = Sprinkles::Opts::GetOpt.convert_str(values.fetch(field.name), field.type)
         elsif !field.factory.nil?

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -141,6 +141,8 @@ module Sprinkles
 
       const :opt_integer, T.nilable(Integer), short: 'e'
       const :def_integer, Integer, short: 'f', factory: -> { 55 }
+
+      const :def_bool, T::Boolean, short: 'g', factory: -> { true }
     end
 
     def test_nilable_with_nil
@@ -154,6 +156,8 @@ module Sprinkles
 
       assert_nil(opts.opt_integer)
       assert_equal(55, opts.def_integer)
+
+      assert_equal(true, opts.def_bool)
     end
 
     def test_nilable_with_values


### PR DESCRIPTION
Right now, booleans always default to `false` even when they have a factory. This fixes that.