### PR TITLE
Fix parsing for short form enums

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -47,7 +47,7 @@ module Sprinkles::Opts
           # if the type is an enum, we can enumerate the possible
           # values in a rich way
           possible_values = type.values.map(&:serialize).join("|")
-          return "[#{possible_values}]"
+          return "<#{possible_values}>"
         end
         placeholder || default
       end
@@ -210,7 +210,12 @@ module Sprinkles::Opts
           default = field.factory&.call if !field.factory.nil?
           v = !!values.fetch(field.name, default)
         elsif values.include?(field.name)
-          v = Sprinkles::Opts::GetOpt.convert_str(values.fetch(field.name), field.type)
+          val = values.fetch(field.name)
+          begin
+            v = Sprinkles::Opts::GetOpt.convert_str(val, field.type)
+          rescue KeyError => exn
+            usage!("Invalid value `#{val}` for field `#{field.name}`:\n  #{exn.message}")
+          end
         elsif !field.factory.nil?
           v = T.must(field.factory).call
         elsif field.optional?

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -184,26 +184,31 @@ module Sprinkles
       sig { override.returns(String) }
       def self.program_name; "opts-with-enum"; end
 
-      const :value, MyEnum, long: "value"
+      const :value, MyEnum, short: 'v', long: "value"
     end
 
     def test_usage_string_for_enums
       help_text = capture_usage { OptsWithEnum.parse(['--help']) }
-      assert(help_text.include?('--value=[one|two]'))
+      assert(help_text.include?('--value=<one|two>'))
     end
 
     def test_enum_values
+      opts = OptsWithEnum.parse(%w[-v one])
+      assert_equal(MyEnum::One, opts.value)
+
       opts = OptsWithEnum.parse(%w[--value=one])
       assert_equal(MyEnum::One, opts.value)
+
+      opts = OptsWithEnum.parse(%w[-v two])
+      assert_equal(MyEnum::Two, opts.value)
 
       opts = OptsWithEnum.parse(%w[--value=two])
       assert_equal(MyEnum::Two, opts.value)
 
-      msg = assert_raises(KeyError) do
+      msg = capture_usage do
         opts = OptsWithEnum.parse(%w[--value=seventeen])
       end
-      msg = T.cast(msg, KeyError)
-      assert(msg.message.include?('key not found: "seventeen"'))
+      assert(msg.include?('key not found: "seventeen"'))
     end
 
     def test_disallow_leading_short_hyphens


### PR DESCRIPTION
Because `getopt` treats `[...]` as an optional arg, we can't put the various options for enums in square brackets. This uses angle brackets instead, which works for `getopt` and looks good enough.