### PR TITLE
Add support for `T::Array` and `T::Set` fields

### DIFF
--- a/lib/sprinkles/opts.rb
+++ b/lib/sprinkles/opts.rb
@@ -239,6 +239,9 @@ module Sprinkles::Opts
               v = values.fetch(field.name).map do |val|
                 Sprinkles::Opts::GetOpt.convert_str(val, field.type.type)
               end
+              # we allow both arrays and sets but we use arrays
+              # internally, so convert to a set just in case
+              v = v.to_set if field.type.is_a?(T::Types::TypedSet)
             end
           rescue KeyError => exn
             usage!("Invalid value `#{val}` for field `#{field.name}`:\n  #{exn.message}")
@@ -248,7 +251,11 @@ module Sprinkles::Opts
         elsif field.optional?
           v = nil
         elsif field.repeated?
-          v = []
+          if field.type.is_a?(T::Types::TypedArray)
+            v = []
+          else
+            v = Set.new
+          end
         else
           usage!("Expected a value for `#{field.name}`")
         end

--- a/test/sprinkles/opts_test.rb
+++ b/test/sprinkles/opts_test.rb
@@ -139,6 +139,29 @@ module Sprinkles
       assert_equal([:two, :three, :four, :five], opts.second)
     end
 
+    class SetPositional < Sprinkles::Opts::GetOpt
+      const :first, String
+      const :second, T::Set[Symbol]
+    end
+
+    def test_set_positional_params
+      opts = SetPositional.parse(%w[one])
+      assert_equal('one', opts.first)
+      assert_equal(Set[], opts.second)
+
+      opts = SetPositional.parse(%w[one two])
+      assert_equal('one', opts.first)
+      assert_equal(Set[:two], opts.second)
+
+      opts = SetPositional.parse(%w[one two three])
+      assert_equal('one', opts.first)
+      assert_equal(Set[:two, :three], opts.second)
+
+      opts = SetPositional.parse(%w[one two three four five])
+      assert_equal('one', opts.first)
+      assert_equal(Set[:two, :three, :four, :five], opts.second)
+    end
+
     def test_all_mandatory_first
       msg = assert_raises(RuntimeError) do
         Class.new(Sprinkles::Opts::GetOpt) do


### PR DESCRIPTION
This allows fields to have values of type `T::Array` or `T::Set`. When a field has one of these sequence types _and it's positional_, then it must be the last positional argument, and it cannot be used with optional arguments (because otherwise there's an ambiguity about how to place them.) When a field has one of these types _and it's given with a flag_, then that flag can be specified more than once in order to provide multiple values.